### PR TITLE
fixed edit flashcard bug

### DIFF
--- a/app/controllers/flashcard_templates_controller.rb
+++ b/app/controllers/flashcard_templates_controller.rb
@@ -38,8 +38,9 @@ class FlashcardTemplatesController < ApplicationController
 
   def update
     authorize @flashcard_template
+    @flashcard_set = FlashcardSet.find(params[:flashcard_set_id])
     if @flashcard_template.update(flashcard_template_params)
-      redirect_to @flashcard_template
+      redirect_to flashcard_set_path(@flashcard_set)
     else
       render :edit
     end

--- a/app/views/flashcard_templates/edit.html.erb
+++ b/app/views/flashcard_templates/edit.html.erb
@@ -1,7 +1,7 @@
 <div class="container my-5">
   <h1>Edit the flashcard</h1>
 
-  <%= simple_form_for [@flashcard_set, @flashcard_template] do |f| %>
+  <%= simple_form_for [@flashcard_set, @flashcard_template], method: :patch do |f| %>
     <%= f.input :question %>
     <%= f.input :answer %>
     <div>


### PR DESCRIPTION
Notice that sometimes you cannot delete flashcard templates because you made student flashcards that depend on them. Gives a nasty looking error but it's not a bug, it's just how our database is made